### PR TITLE
Add license and enhance secrets

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/apis/argoproj/v1alpha1/argocd_types.go
+++ b/pkg/apis/argoproj/v1alpha1/argocd_types.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package v1alpha1
 
 import (

--- a/pkg/controller/argocd/argocd_controller.go
+++ b/pkg/controller/argocd/argocd_controller.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (

--- a/pkg/controller/argocd/grafana.go
+++ b/pkg/controller/argocd/grafana.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (

--- a/pkg/controller/argocd/prometheus.go
+++ b/pkg/controller/argocd/prometheus.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (
@@ -115,7 +129,7 @@ func (r *ReconcileArgoCD) reconcileServerMetricsServiceMonitor(cr *argoproj.Argo
 
 	sm.Spec.Selector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"app.kubernetes.io/name": "argocd-server",
+			"app.kubernetes.io/name": "argocd-server-metrics",
 		},
 	}
 	sm.Spec.Endpoints = []monitoringv1.Endpoint{

--- a/pkg/controller/argocd/route.go
+++ b/pkg/controller/argocd/route.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (

--- a/pkg/controller/argocd/secret.go
+++ b/pkg/controller/argocd/secret.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (
@@ -25,12 +39,42 @@ func newSecret(name string, namespace string) *corev1.Secret {
 	}
 }
 
-func (r *ReconcileArgoCD) reconcileSecrets(cr *argoproj.ArgoCD) error {
+func (r *ReconcileArgoCD) reconcileArgoSecret(cr *argoproj.ArgoCD) error {
 	secret := newSecret("argocd-secret", cr.Namespace)
 	found := r.isObjectFound(types.NamespacedName{Namespace: cr.Namespace, Name: secret.Name}, secret)
 	if found {
-		// Secret found, do nothing
-		return nil
+		return nil // Secret found, do nothing
+	}
+
+	if err := controllerutil.SetControllerReference(cr, secret, r.scheme); err != nil {
+		return err
+	}
+	return r.client.Create(context.TODO(), secret)
+}
+
+func (r *ReconcileArgoCD) reconcileSecrets(cr *argoproj.ArgoCD) error {
+	if err := r.reconcileArgoSecret(cr); err != nil {
+		return err
+	}
+
+	if IsOpenShift() {
+		if err := r.reconcileGrafanaSecret(cr); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileArgoCD) reconcileGrafanaSecret(cr *argoproj.ArgoCD) error {
+	secret := newSecret("argocd-grafana-secret", cr.Namespace)
+	found := r.isObjectFound(types.NamespacedName{Namespace: cr.Namespace, Name: secret.Name}, secret)
+	if found {
+		return nil // Secret found, do nothing
+	}
+
+	secret.Data = map[string][]byte{
+		"admin": []byte("secret"),
 	}
 
 	if err := controllerutil.SetControllerReference(cr, secret, r.scheme); err != nil {

--- a/pkg/controller/argocd/service.go
+++ b/pkg/controller/argocd/service.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (

--- a/pkg/controller/argocd/util.go
+++ b/pkg/controller/argocd/util.go
@@ -1,3 +1,17 @@
+// Copyright 2019 ArgoCD Operator Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argocd
 
 import (


### PR DESCRIPTION
-  Add the license to each of the maintained go files.
- Fix name for the argo server-mertrics service monitor.
- Refactor secret reconcile to add additional secrets.
