### PR TITLE
Add Chacks for Enabled Insights 

### DIFF
--- a/examples/argocd-basic.yaml
+++ b/examples/argocd-basic.yaml
@@ -1,9 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
-  name: argocd-basic
+  name: example-argocd
   labels:
-    purpose: example
     example: basic
 spec:
   version: v1.2.3

--- a/examples/argocd-insecure.yaml
+++ b/examples/argocd-insecure.yaml
@@ -1,9 +1,8 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
-  name: argocd-insecure
+  name: example-argocd
   labels:
-    purpose: example
     example: insecure
 spec:
   server:

--- a/examples/argocd-lb.yaml
+++ b/examples/argocd-lb.yaml
@@ -3,10 +3,8 @@ kind: ArgoCD
 metadata:
   name: example-argocd
   labels:
-    purpose: example
     example: lb
 spec:
   server:
-    insecure: false
     service:
       type: LoadBalancer

--- a/pkg/controller/argocd/configmap.go
+++ b/pkg/controller/argocd/configmap.go
@@ -142,6 +142,10 @@ func (r *ReconcileArgoCD) reconcileConfiguration(cr *argoproj.ArgoCD) error {
 
 // reconcileGrafanaConfiguration will ensure that the Grafana configuration ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoproj.ArgoCD) error {
+	if !cr.Spec.Grafana.Enabled {
+		return nil // Grafana not enabled, do nothing.
+	}
+
 	cm := newConfigMapWithSuffix(ArgoCDGrafanaConfigMapSuffix, cr)
 	if r.isObjectFound(cr.Namespace, cm.Name, cm) {
 		return nil // ConfigMap found, do nothing
@@ -178,6 +182,10 @@ func (r *ReconcileArgoCD) reconcileGrafanaConfiguration(cr *argoproj.ArgoCD) err
 
 // reconcileGrafanaDashboards will ensure that the Grafana dashboards ConfigMap is present.
 func (r *ReconcileArgoCD) reconcileGrafanaDashboards(cr *argoproj.ArgoCD) error {
+	if !cr.Spec.Grafana.Enabled {
+		return nil // Grafana not enabled, do nothing.
+	}
+
 	cm := newConfigMapWithSuffix(ArgoCDGrafanaDashboardConfigMapSuffix, cr)
 	if r.isObjectFound(cr.Namespace, cm.Name, cm) {
 		return nil // ConfigMap found, do nothing

--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -275,6 +275,10 @@ func (r *ReconcileArgoCD) reconcileGrafanaDeployment(cr *argoproj.ArgoCD) error 
 		return nil // Deployment found, do nothing
 	}
 
+	if !cr.Spec.Grafana.Enabled {
+		return nil // Grafana not enabled, do nothing.
+	}
+
 	deploy.Spec.Replicas = getGrafanaReplicas(cr)
 
 	deploy.Spec.Template.Spec.Containers = []corev1.Container{{

--- a/pkg/controller/argocd/ingress.go
+++ b/pkg/controller/argocd/ingress.go
@@ -209,11 +209,15 @@ func (r *ReconcileArgoCD) reconcileArgoServerGRPCIngress(cr *argoproj.ArgoCD) er
 func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("grafana", cr)
 	if r.isObjectFound(cr.Namespace, ingress.Name, ingress) {
-		if !cr.Spec.Ingress.Enabled {
+		if !cr.Spec.Ingress.Enabled || !cr.Spec.Grafana.Enabled {
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
 			return r.client.Delete(context.TODO(), ingress)
 		}
 		return nil // Ingress found and enabled, do nothing
+	}
+
+	if !cr.Spec.Grafana.Enabled {
+		return nil // Grafana not enabled, do nothing.
 	}
 
 	// Add annotations
@@ -260,11 +264,15 @@ func (r *ReconcileArgoCD) reconcileGrafanaIngress(cr *argoproj.ArgoCD) error {
 func (r *ReconcileArgoCD) reconcilePrometheusIngress(cr *argoproj.ArgoCD) error {
 	ingress := newIngressWithSuffix("prometheus", cr)
 	if r.isObjectFound(cr.Namespace, ingress.Name, ingress) {
-		if !cr.Spec.Ingress.Enabled {
+		if !cr.Spec.Ingress.Enabled || !cr.Spec.Prometheus.Enabled {
 			// Ingress exists but enabled flag has been set to false, delete the Ingress
 			return r.client.Delete(context.TODO(), ingress)
 		}
 		return nil // Ingress found and enabled, do nothing
+	}
+
+	if !cr.Spec.Prometheus.Enabled {
+		return nil // Prometheus not enabled, do nothing.
 	}
 
 	// Add annotations

--- a/pkg/controller/argocd/prometheus.go
+++ b/pkg/controller/argocd/prometheus.go
@@ -110,6 +110,10 @@ func (r *ReconcileArgoCD) reconcileMetricsServiceMonitor(cr *argoproj.ArgoCD) er
 		return nil // ServiceMonitor found, do nothing
 	}
 
+	if !cr.Spec.Prometheus.Enabled {
+		return nil // Prometheus not enabled, do nothing.
+	}
+
 	sm.Spec.Selector = metav1.LabelSelector{
 		MatchLabels: map[string]string{
 			ArgoCDKeyName: nameWithSuffix(ArgoCDKeyMetrics, cr),

--- a/pkg/controller/argocd/route.go
+++ b/pkg/controller/argocd/route.go
@@ -76,11 +76,11 @@ func (r *ReconcileArgoCD) reconcileRoutes(cr *argoproj.ArgoCD) error {
 		return err
 	}
 
-	if err := r.reconcileServerRoute(cr); err != nil {
+	if err := r.reconcilePrometheusRoute(cr); err != nil {
 		return err
 	}
 
-	if err := r.reconcilePrometheusRoute(cr); err != nil {
+	if err := r.reconcileServerRoute(cr); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/argocd/service.go
+++ b/pkg/controller/argocd/service.go
@@ -103,6 +103,10 @@ func (r *ReconcileArgoCD) reconcileGrafanaService(cr *argoproj.ArgoCD) error {
 		return nil // Service found, do nothing
 	}
 
+	if !cr.Spec.Grafana.Enabled {
+		return nil // Grafana not enabled, do nothing.
+	}
+
 	svc.Spec.Selector = map[string]string{
 		ArgoCDKeyName: nameWithSuffix("grafana", cr),
 	}
@@ -267,6 +271,11 @@ func (r *ReconcileArgoCD) reconcileServices(cr *argoproj.ArgoCD) error {
 		return err
 	}
 
+	err = r.reconcileGrafanaService(cr)
+	if err != nil {
+		return err
+	}
+
 	err = r.reconcileMetricsService(cr)
 	if err != nil {
 		return err
@@ -288,11 +297,6 @@ func (r *ReconcileArgoCD) reconcileServices(cr *argoproj.ArgoCD) error {
 	}
 
 	err = r.reconcileServerService(cr)
-	if err != nil {
-		return err
-	}
-
-	err = r.reconcileGrafanaService(cr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds various checks for the grafana/prometheus enabled flags where needed to ensure resources are created/removed when the enabled flags are changed. Also cleaned up the examples to be more consistent.