### PR TITLE
Added the http scheme to dex-server url

### DIFF
--- a/pkg/controller/argocd/deployment.go
+++ b/pkg/controller/argocd/deployment.go
@@ -63,7 +63,7 @@ func getArgoServerCommand(cr *argoproj.ArgoCD) []string {
 	cmd = append(cmd, "argocd-server")
 
 	cmd = append(cmd, "--dex-server")
-	cmd = append(cmd, nameWithSuffix("dex-server:5556", cr))
+	cmd = append(cmd, fmt.Sprintf("%s://%s", "http", nameWithSuffix("dex-server:5556", cr)))
 
 	cmd = append(cmd, "--redis")
 	cmd = append(cmd, nameWithSuffix("redis:6379", cr))


### PR DESCRIPTION
When using a SSO configuration by editing the argocd-cm ConfigMap with Dex connector settings, I got the following error

```
Failed to query provider "https://argocd-server-argocd.example.com/api/dex": Get argocd-dex-server:///api/dex/.well-known/openid-configuration: unsupported protocol scheme "argocd-dex-server"
```

Adding the scheme (http) to the argocd-server deployment resource solved the issue.

```
name: argocd-server
          command:
            - argocd-server
            - '--dex-server'
            - '**http://**argocd-dex-server:5556'
            - '--redis'
            - 'argocd-redis:6379'
            - '--repo-server'
            - 'argocd-repo-server:8081'
            - '--insecure'
            - '--staticassets'
            - /shared/app
```